### PR TITLE
Add files via upload

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/static_route.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/static_route.json
@@ -1,0 +1,8 @@
+{
+    "STATIC_ROUTE_TEST": {
+        "desc": "Configure basic static route with default VRFs with PREFIX"
+    },
+    "STATIC_ROUTE_TEST_WITH_INTERFACE": {
+        "desc": "Configure with nexthop as interface instead of IP address"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/static_route.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/static_route.json
@@ -4,5 +4,15 @@
     },
     "STATIC_ROUTE_TEST_WITH_INTERFACE": {
         "desc": "Configure with nexthop as interface instead of IP address"
+    },
+    "STATIC_ROUTE_TEST_WITH_BLACKHOLE": {
+        "desc": "Configure with nexthop as blackhole"
+    },
+    "STATIC_ROUTE_TEST_WITH_VRF": {
+        "desc": "Configure with routes in non default VRF"
+    },
+    "STATIC_ROUTE_TEST_WITH_VRF_LEAK": {
+        "desc": "Configure with route leak across VRFS"
     }
+
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/static-route.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/static-route.json
@@ -191,11 +191,79 @@
                 "STATIC_ROUTE_LIST": [{
 			"prefix": "75.75.75.0/24",
 			"vrf_name": "VrfMav",
-			"nexthop": "1.1.1.2",
+			"nexthop": "1.0.0.2",
 			"ifname": "Ethernet8",
 			"distance": "1",
 		        "nexthop-vrf": "VrfMav",
 		        "blackhole": "false"
+                }]
+            }
+        }
+    },
+    "STATIC_ROUTE_TEST_WITH_VRF_LEAK": {
+         "sonic-vrf:sonic-vrf": {
+           "VRF": {
+             "VRF_LIST": [
+               {
+                 "name": "VrfMav",
+                 "fallback": true
+               }
+              ]
+            }
+         },
+	     "sonic-vrf:sonic-vrf": {
+           "VRF": {
+             "VRF_LIST": [
+               {
+                 "name": "VrfAbc",
+                 "fallback": true
+               }
+              ]
+            }
+         },
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "family": "IPv4",
+                        "ip-prefix": "1.0.0.1/30",
+                        "name": "Ethernet8",
+                        "scope": "global"
+                    }
+                ],
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8"
+                    }
+                ]
+            }
+        },
+       "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet8",
+                        "fec": "rs",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet8",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-static-route:sonic-static-route": {
+            "sonic-static-route:STATIC_ROUTE": {
+                "STATIC_ROUTE_LIST": [{
+                        "prefix": "85.85.85.0/24",
+                        "vrf_name": "VrfMav",
+                        "nexthop": "1.0.0.2",
+                        "ifname": "Ethernet8",
+                        "distance": "1",
+                        "nexthop-vrf": "VrfAbc",
+                        "blackhole": "false"
                 }]
             }
         }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/static-route.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/static-route.json
@@ -1,0 +1,203 @@
+{
+    "STATIC_ROUTE_TEST": {
+	"sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "family": "IPv4",
+                        "ip-prefix": "10.0.0.1/24",
+                        "name": "Ethernet8",
+                        "scope": "global"
+                    }
+                ],
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8"
+                    }
+                ]
+            }
+        },
+       "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet8",
+                        "fec": "rs",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet8",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-static-route:sonic-static-route": {
+            "sonic-static-route:STATIC_ROUTE": {
+                "STATIC_ROUTE_LIST": [{
+                        "vrf_name": "default",
+			"prefix":"100.100.100.1/24",
+			"nexthop":"10.10.10.1",
+			"distance": "1",
+			"nexthop-vrf":"default",
+			"blackhole":"false"
+                }]
+            }
+        }
+    },
+    "STATIC_ROUTE_TEST_WITH_INTERFACE": {
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "family": "IPv4",
+                        "ip-prefix": "10.0.0.1/30",
+                        "name": "Ethernet8",
+                        "scope": "global"
+                    }
+                ],
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8"
+                    }
+                ]
+            }
+        },
+       "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet8",
+                        "fec": "rs",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet8",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },	
+        "sonic-static-route:sonic-static-route": {
+            "sonic-static-route:STATIC_ROUTE": {
+                "STATIC_ROUTE_LIST": [{
+                        "vrf_name": "default",
+                        "prefix":"100.100.100.1/24",
+			"nexthop":"0.0.0.0",
+                        "ifname":"Ethernet8",
+                        "distance": "1",
+                        "nexthop-vrf":"default",
+                        "blackhole":"false"
+                }]
+            }
+        }
+    },
+    "STATIC_ROUTE_TEST_WITH_BLACKHOLE": {
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "family": "IPv4",
+                        "ip-prefix": "10.0.0.1/30",
+                        "name": "Ethernet8",
+                        "scope": "global"
+                    }
+                ],
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8"
+                    }
+                ]
+            }
+        },
+       "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet8",
+                        "fec": "rs",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet8",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-static-route:sonic-static-route": {
+            "sonic-static-route:STATIC_ROUTE": {
+                "STATIC_ROUTE_LIST": [{
+			"prefix": "150.150.150.0/24",
+			"vrf_name": "default",
+			"ifname": "Ethernet8",
+			"distance": "1",
+			"nexthop-vrf": "default",
+			"blackhole": "true"
+                }]
+            }
+        }
+    },
+
+  "STATIC_ROUTE_TEST_WITH_VRF": {
+	 "sonic-vrf:sonic-vrf": {
+	   "VRF": {
+	     "VRF_LIST": [
+	       {
+		 "name": "VrfMav",
+		 "fallback": true
+	       }
+	      ]
+	    }
+	 },
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "family": "IPv4",
+                        "ip-prefix": "1.0.0.1/30",
+                        "name": "Ethernet8",
+                        "scope": "global"
+                    }
+                ],
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8"
+                    }
+                ]
+            }
+        },
+       "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth8",
+                        "description": "Ethernet8",
+                        "fec": "rs",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet8",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-static-route:sonic-static-route": {
+            "sonic-static-route:STATIC_ROUTE": {
+                "STATIC_ROUTE_LIST": [{
+			"prefix": "75.75.75.0/24",
+			"vrf_name": "VrfMav",
+			"nexthop": "1.1.1.2",
+			"ifname": "Ethernet8",
+			"distance": "1",
+		        "nexthop-vrf": "VrfMav",
+		        "blackhole": "false"
+                }]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/static-route.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/static-route.json
@@ -191,7 +191,7 @@
                 "STATIC_ROUTE_LIST": [{
 			"prefix": "75.75.75.0/24",
 			"vrf_name": "VrfMav",
-			"nexthop": "1.0.0.2",
+			"nexthop": "1.1.1.2",
 			"ifname": "Ethernet8",
 			"distance": "1",
 		        "nexthop-vrf": "VrfMav",
@@ -200,18 +200,8 @@
             }
         }
     },
-    "STATIC_ROUTE_TEST_WITH_VRF_LEAK": {
-         "sonic-vrf:sonic-vrf": {
-           "VRF": {
-             "VRF_LIST": [
-               {
-                 "name": "VrfMav",
-                 "fallback": true
-               }
-              ]
-            }
-         },
-	     "sonic-vrf:sonic-vrf": {
+     "STATIC_ROUTE_TEST_WITH_VRF_LEAK": {
+	 "sonic-vrf:sonic-vrf": {
            "VRF": {
              "VRF_LIST": [
                {
@@ -258,7 +248,7 @@
             "sonic-static-route:STATIC_ROUTE": {
                 "STATIC_ROUTE_LIST": [{
                         "prefix": "85.85.85.0/24",
-                        "vrf_name": "VrfMav",
+                        "vrf_name": "default",
                         "nexthop": "1.0.0.2",
                         "ifname": "Ethernet8",
                         "distance": "1",

--- a/src/sonic-yang-models/yang-models/sonic-static-route.yang
+++ b/src/sonic-yang-models/yang-models/sonic-static-route.yang
@@ -1,0 +1,100 @@
+module sonic-static-route {
+  yang-version 1.1;
+  namespace "http://github.com/Azure/sonic-static-route";
+  prefix sroute;
+
+  import sonic-vrf {
+    prefix vrf;
+  }
+  import ietf-inet-types {
+    prefix inet;
+  }
+  import sonic-types {
+    prefix stypes;
+  }
+
+  organization
+    "SONiC";
+  contact
+    "SONiC";
+  description
+    "STATIC ROUTE yang Module for SONiC OS";
+
+  revision 2022-03-17 {
+    description
+      "First Revision";
+  }
+
+  container sonic-static-route {
+    container STATIC_ROUTE {
+      description
+        "STATIC_ROUTE part of config_db.json";
+      list STATIC_ROUTE_LIST {
+        key "vrf_name prefix";
+        leaf prefix {
+          type stypes:sonic-ip4-prefix;
+          description
+            "prefix is the destination IP address, as key";
+        }
+        leaf vrf_name {
+          type union {
+            type string {
+              pattern 'default';
+            }
+            type leafref {
+              path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+            }
+          }
+          description
+            "Virtual Routing Instance name as key";
+        }
+        leaf nexthop {
+          type inet:ip-address;
+          description
+            "The next-hop that is to be used for the
+             static route as IP address. When interface needs to be
+             specified, use 0.0.0.0 as leaf value";
+        }
+        leaf ifname {
+          type string {
+            pattern 'Ethernet([1-3][0-9]{3}|[1-9][0-9]{2}|[1-9][0-9]|[0-9])' {
+              error-message "Invalid interface name";
+              error-app-tag "interface-name-invalid";
+            }
+          }
+          description
+            "When interface is specified, forwarding happens through it";
+        }
+        leaf distance {
+          type string;
+          description
+            "Administrative Distance (preference) of the entry.  The
+             preference defines the order of selection when multiple
+             sources (protocols, static, etc.) contribute to the same
+             prefix entry.  The lower the preference, the more preferable the
+             prefix is.  When this value is not specified, the preference is
+             inherited from the default preference of the implementation for
+             static routes.";
+        }
+        leaf nexthop-vrf {
+          type union {
+            type string {
+              pattern 'default';
+            }
+            type leafref {
+              path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+            }
+          }
+          description
+            "VRF name of the nexthop. This is for vrf leaking";
+        }
+        leaf blackhole {
+          type string;
+          default "false";
+          description
+            "blackhole refers to a route that, if matched, discards the message silently.";
+        }
+      } /* end of list STATIC_ROUTE_LIST */
+    } /* end of container STATIC_ROUTE */
+  } /* end of container sonic-static_route */
+}


### PR DESCRIPTION
[sonic-yang-models]: First version of yang model for static route.
Yang models as per guidelines. 
Guideline doc: https://github.com/Azure/SONiC/blob/master/doc/mgmt/SONiC_YANG_Model_Guidelines.md

What I did 
Created Yang model for Sonic. 
Table -> STATIC_ROUTE

Why I did it
To create static route configuration through YANG

UT test cases:

[static-route-ut.txt](https://github.com/UmaMaven/sonic-buildimage/files/8915758/static-route-ut.txt)


Signed-off-by: uma.ramanathan@mavenir.com
